### PR TITLE
Add clerk

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ mv $GOPATH/bin/wcafe-cli $GOPATH/bin/wcafe
 wcafe stores list
 wcafe pets　list
 wcafe users　list
+wcafe clerks list
 ```
 ### 新規作成の場合
 ```
 wcafe stores　create
 wcafe pets  create <store_id>
 wcafe users create
+wcafe clerks create -n(--name) hogehoge
+(オプションは指定しなくても利用可)
 ```

--- a/cmd/clerks.go
+++ b/cmd/clerks.go
@@ -3,54 +3,51 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"io/ioutil"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-// storesコマンドの定義
-func newStoresCmd() *cobra.Command {
+// clerksコマンドの定義
+func newClerksCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "stores",
-		Short: "stores command",
+		Use:   "clerks",
+		Short: "clerks command",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},
 	}
 	// サブコマンドの追加
 	cmd.AddCommand(
-		newStoresListCmd(),
-		newStoresCreateCmd(),
+		newClerksListCmd(),
+		newClerksCreateCmd(),
 	)
 	return cmd
 }
 
-func newStoresListCmd() *cobra.Command {
+func newClerksListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Get stores list",
-		RunE:  runStoresListCmd,
+		Short: "Get clerks list",
+		RunE:  runClerksListCmd,
 	}
 	return cmd
 }
 
-func newStoresCreateCmd() *cobra.Command {
+func newClerksCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a store",
-		RunE:  runStoresCreateCmd,
+		Short: "Create a clerk",
+		RunE:  runClerksCreateCmd,
 	}
 	return cmd
 }
 
-// stores list の出力
-func runStoresListCmd(cmd *cobra.Command, args []string) error {
+// clerks list の出力
+func runClerksListCmd(cmd *cobra.Command, args []string) error {
 	client, err := newDefaultClient()
 	if err != nil {
 		return errors.Wrap(err, "newClient failed:")
@@ -59,18 +56,18 @@ func runStoresListCmd(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	body, err := client.StoreList(ctx)
+	body, err := client.ClerkList(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "StoreList was failed:body = %+v", body)
+		return errors.Wrapf(err, "ClerkList was failed:body = %+v", body)
 	}
 	fmt.Println(body)
 
 	return nil
 }
 
-// stores list の処理
-func (client *Client) StoreList(ctx context.Context) (string, error) {
-	subPath := fmt.Sprintf("/stores")
+// clerks list の処理
+func (client *Client) ClerkList(ctx context.Context) (string, error) {
+	subPath := fmt.Sprintf("/clerks")
 	req, err := client.newRequest(ctx, "GET", subPath, nil)
 	if err != nil {
 		return "error", errors.Wrapf(err, "newRequest was faild:req= %+v", req)
@@ -88,15 +85,8 @@ func (client *Client) StoreList(ctx context.Context) (string, error) {
 	return string(body), nil
 }
 
-// ランダムな文字列の生成
-func random() string {
-	var n uint64
-	binary.Read(rand.Reader, binary.LittleEndian, &n)
-	return strconv.FormatUint(n, 36)
-}
-
-// stores createの出力
-func runStoresCreateCmd(cmd *cobra.Command, args []string) error {
+// clerks createの出力
+func runClerksCreateCmd(cmd *cobra.Command, args []string) error {
 	client, err := newDefaultClient()
 	if err != nil {
 		return errors.Wrap(err, "newClient failed:")
@@ -105,24 +95,22 @@ func runStoresCreateCmd(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	body, err := client.StoreCreate(ctx)
+	body, err := client.ClerkCreate(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "StoreCreate was failed:body = %+v", body)
+		return errors.Wrapf(err, "ClerkCreate was failed:body = %+v", body)
 	}
 	fmt.Println(body)
 
 	return nil
 }
 
-// stores createの処理
-func (client *Client) StoreCreate(ctx context.Context) (string, error) {
-	subPath := fmt.Sprintf("/stores")
+// clerks createの処理
+func (client *Client) ClerkCreate(ctx context.Context) (string, error) {
+	subPath := fmt.Sprintf("/clerks")
 
 	// POSTするデータ
 	jsonStr := `{
-	"name": "` + random() + `",
-    "tag":"CLI",
-    "address":"Okinawa"
+	"Name": "climan"
 	}`
 	req, err := client.newRequest(ctx, "POST", subPath, bytes.NewBuffer([]byte(jsonStr)))
 	if err != nil {
@@ -140,5 +128,4 @@ func (client *Client) StoreCreate(ctx context.Context) (string, error) {
 		return "error", errors.Wrapf(err, "ReadAll was faild:body=%+v", body)
 	}
 	return string(body), nil
-
 }

--- a/cmd/clerks.go
+++ b/cmd/clerks.go
@@ -37,12 +37,23 @@ func newClerksListCmd() *cobra.Command {
 	return cmd
 }
 
+type Clerks struct {
+	Name string
+}
+
 func newClerksCreateCmd() *cobra.Command {
+
+	var (
+		cl = &Clerks{}
+	)
 	cmd := &cobra.Command{
-		Use:   "create",
+		Use:   "create [flag]",
 		Short: "Create a clerk",
-		RunE:  runClerksCreateCmd,
+		Run: func(cmd *cobra.Command, args []string) {
+			runClerksCreateOpt(cmd, cl)
+		},
 	}
+	cmd.Flags().StringVarP(&cl.Name, "name", "n", "climan", "change name")
 	return cmd
 }
 
@@ -85,8 +96,18 @@ func (client *Client) ClerkList(ctx context.Context) (string, error) {
 	return string(body), nil
 }
 
+// create時のオプション有無の判断
+func runClerksCreateOpt(cmd *cobra.Command, opt *Clerks) {
+	if len(opt.Name) != 0 {
+		runClerksCreateCmd(cmd, opt.Name)
+	} else {
+		opt.Name = "climan"
+		runClerksCreateCmd(cmd, opt.Name)
+	}
+}
+
 // clerks createの出力
-func runClerksCreateCmd(cmd *cobra.Command, args []string) error {
+func runClerksCreateCmd(cmd *cobra.Command, optName string) error {
 	client, err := newDefaultClient()
 	if err != nil {
 		return errors.Wrap(err, "newClient failed:")
@@ -95,7 +116,7 @@ func runClerksCreateCmd(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	body, err := client.ClerkCreate(ctx)
+	body, err := client.ClerkCreate(ctx, optName)
 	if err != nil {
 		return errors.Wrapf(err, "ClerkCreate was failed:body = %+v", body)
 	}
@@ -105,12 +126,11 @@ func runClerksCreateCmd(cmd *cobra.Command, args []string) error {
 }
 
 // clerks createの処理
-func (client *Client) ClerkCreate(ctx context.Context) (string, error) {
+func (client *Client) ClerkCreate(ctx context.Context, optName string) (string, error) {
 	subPath := fmt.Sprintf("/clerks")
-
 	// POSTするデータ
 	jsonStr := `{
-	"Name": "climan"
+	"Name": "` + optName + `"
 	}`
 	req, err := client.newRequest(ctx, "POST", subPath, bytes.NewBuffer([]byte(jsonStr)))
 	if err != nil {

--- a/cmd/clerks_test.go
+++ b/cmd/clerks_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestClerkListOk(t *testing.T) {
+	cases := []struct {
+		body string
+	}{
+		{
+			body: `[
+				{
+					"NameId": "cc5bafac-b35c-4852-82ca-b272cd79f2f3",
+					"Name": "kato"
+				},
+				{
+					"NameId": "cc2jgodl-f03d-7593-83ya-b645cg64f2f5", 
+					"Name": "kosaka"
+				}
+			]`,
+		},
+		{
+			body: "[]",
+		},
+	}
+
+	for _, tc := range cases {
+		mux, mockServerURL := newMockServer()
+		client := newTestClient(mockServerURL)
+		hundlePath := fmt.Sprintf("/api/clerks")
+
+		// mockのパターンをセット
+		mux.HandleFunc(hundlePath, func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, tc.body)
+		})
+
+		res, err := client.ClerkList(context.Background())
+		if err != nil {
+			t.Fatalf("ClerkList was failed:list = %+v, err = %+v", res, err)
+		}
+
+		if !reflect.DeepEqual(res, tc.body) {
+			t.Errorf("list = %+v, body = %+v", res, tc.body)
+		}
+	}
+}
+
+func TestClerkCreateOk(t *testing.T) {
+	body := `{"NameId": "sa5bafac-b35c-4852-82ca-b272cd79f2f3", "Name": "sasaki"}`
+
+	mux, mockServerURL := newMockServer()
+	client := newTestClient(mockServerURL)
+	hundlePath := fmt.Sprintf("/api/clerks")
+
+	// Mockパターンをセット
+	mux.HandleFunc(hundlePath, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	})
+
+	create, err := client.ClerkCreate(context.Background())
+	if err != nil {
+		t.Fatalf("ClerkCreate was failed:create = %+v, err = %+v", create, err)
+	}
+
+	if !reflect.DeepEqual(create, body) {
+		t.Errorf("create = %+v, body = %+v", create, body)
+	}
+}

--- a/cmd/clerks_test.go
+++ b/cmd/clerks_test.go
@@ -62,7 +62,7 @@ func TestClerkCreateOk(t *testing.T) {
 		fmt.Fprint(w, body)
 	})
 
-	create, err := client.ClerkCreate(context.Background())
+	create, err := client.ClerkCreate(context.Background(), "sasaki")
 	if err != nil {
 		t.Fatalf("ClerkCreate was failed:create = %+v, err = %+v", create, err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,3 +21,11 @@ func newDefaultClient() (*Client, error) {
 	httpClient := &http.Client{}
 	return newClient(endpointURL, httpClient)
 }
+
+// コマンドの追加
+func init() {
+	RootCmd.AddCommand(newStoresCmd())
+	RootCmd.AddCommand(newPetsCmd())
+	RootCmd.AddCommand(newusersCmd())
+	RootCmd.AddCommand(newClerksCmd())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,6 @@ func newDefaultClient() (*Client, error) {
 func init() {
 	RootCmd.AddCommand(newStoresCmd())
 	RootCmd.AddCommand(newPetsCmd())
-	RootCmd.AddCommand(newusersCmd())
+	RootCmd.AddCommand(newUsersCmd())
 	RootCmd.AddCommand(newClerksCmd())
 }

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -14,7 +14,7 @@ import (
 )
 
 // usersコマンドの定義
-func newusersCmd() *cobra.Command {
+func newUsersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "users",
 		Short: "users command",


### PR DESCRIPTION
# やったこと
- /clerksのGETとPOSTの追加
- /clerksのPOSTにNameを自由に変更できるオプションを追加
- 上記のテストの実装
- コマンド追加の関数をroot.goに引っ越し